### PR TITLE
Fix: Terminal won't resize when main window is resized.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 PyQt5
 PyQt-Fluent-Widgets
+pywinpty; platform_system == "Windows"
+ptyprocess; platform_system != "Windows"

--- a/zterm/views/root.py
+++ b/zterm/views/root.py
@@ -78,7 +78,5 @@ class Root(MSFluentWindow):
             terminal : Terminal = tabWidget.widget
             terminal.setGeometry(0, 0, event.size().width(), event.size().height())
             terminal.textedit.resize(event.size())
-            print(event.size())
-            print(terminal.geometry())
             
 

--- a/zterm/views/root.py
+++ b/zterm/views/root.py
@@ -1,6 +1,7 @@
 import uuid
 
 from PyQt5.QtWidgets import QApplication, QStackedWidget
+from PyQt5.QtGui import QResizeEvent
 from qfluentwidgets import FluentIcon as FIF
 from qfluentwidgets import *
 
@@ -67,3 +68,17 @@ class Root(MSFluentWindow):
     def addTab(self, routeKey, text, widget, icon=None):
         self.tabBar.addTab(routeKey, text, icon)
         self.stack.addWidget(ZTermTab(self, routeKey, widget))
+        
+    def resizeEvent(self, event: QResizeEvent) -> None:
+        super().resizeEvent(event)
+
+        if (currentTab := self.tabBar.currentTab()) != None:
+            objectName = currentTab.routeKey()
+            tabWidget = self.findChild(ZTermTab, objectName)
+            terminal : Terminal = tabWidget.widget
+            terminal.setGeometry(0, 0, event.size().width(), event.size().height())
+            terminal.textedit.resize(event.size())
+            print(event.size())
+            print(terminal.geometry())
+            
+


### PR DESCRIPTION
The terminal widget inside the tabs were not resizing when the main window is resized. This was because terminal widget was assigned a default minimum size, and never got a chance to resize itself.

The Solution is to add a resize event to the root widget, and resize both the terminal widget and its textarea child to the max size. 

```python
def resizeEvent(self, event: QResizeEvent) -> None:
        super().resizeEvent(event)

        if (currentTab := self.tabBar.currentTab()) != None:
            objectName = currentTab.routeKey()
            tabWidget = self.findChild(ZTermTab, objectName)
            terminal : Terminal = tabWidget.widget
            terminal.setGeometry(0, 0, event.size().width(), event.size().height())
            terminal.textedit.resize(event.size())
```